### PR TITLE
Silence a few rpmlint noises

### DIFF
--- a/mesa.rpmlintrc
+++ b/mesa.rpmlintrc
@@ -1,5 +1,17 @@
-# False positive (9.1 vs. 9.1.0)
-addFilter("E: incoherent-version-in-name")
+# Mesa-tools contains one private library, while not being a library package
+addFilter("E: executable-in-library-package")
+addFilter("E: non-versioned-file-in-library-package")
 
-# libswrAVX*.so files for dlopen-ing
-addFilter("E: devel-file-in-non-devel-package")
+# .icd and .json config files don't go in %%_libdir
+addFilter("W: non-conffile-in-etc")
+addFilter("E: outside-libdir-files")
+
+# If upstream does not provide a man page we cand do nothing about it
+addFilter("W: no-manual-page-for-binary")
+
+# All the files flagged by rpmlint are private library, so this is OK
+addFilter("E: invalid-soname")
+# ... ditto for libRusticlOpenCL.so
+addFilter("W: devel-file-in-non-devel-package")
+
+#addFilter("E: unused-rpmlintrc-filter")

--- a/mesa.spec
+++ b/mesa.spec
@@ -30,7 +30,7 @@
 
 #define git 20240114
 %define git_branch main
-#define git_branch %(echo %{version} |cut -d. -f1-2)
+#define git_branch %%(echo %%{version} |cut -d. -f1-2)
 #define relc 3
 
 %ifarch %{riscv}
@@ -426,7 +426,7 @@ Obsoletes:	%{_lib}XvMCgallium1 <= 22.0.0-0.rc2.1
 Obsoletes:	vdpau-drivers < %{EVRD}
 
 %description -n %{dridrivers}
-DRI and Vulkan drivers.
+Mesa DRI and Vulkan drivers.
 
 %ifarch %{armx} %{riscv}
 %package -n freedreno-tools
@@ -971,6 +971,10 @@ find %{buildroot} -name '*.la' |xargs rm -f
 # (tpg) remove wayland files as they are now part of wayland package
 rm -rf %{buildroot}%{_libdir}/libwayland-egl.so*
 rm -rf %{buildroot}%{_libdir}/pkgconfig/wayland-egl.pc
+
+# Fix perms
+chmod 0755 %{buildroot}%{_bindir}/mesa-overlay-control.py
+
 
 %files
 %doc docs/README.*


### PR DESCRIPTION
Rpmlint gets confused by
- the presence of private shared libraries in the dri-drivers package;
- ditto for the mesa-tools package;
- the placement of .json and .icd config files.
In addition it complains about missing man pages (but we cannot provide them if upstream does not), plus a couple of minor things.
Update mesa.rpmlintrc to silence the wrong errors/warnings and fix a perms issue.